### PR TITLE
Add posts limit parameter for each endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Options are passed in as data attributes on the entry point div
 ...
 
     <div id="retainable-rss-embed"
-             data-rss="https://medium.com/feed/retainable,
-             https://medium.com/feed/js-dojo,                https://medium.com/feed/vue-mastery"
+             data-rss="https://medium.com/feed/retainable 3,https://medium.com/feed/js-dojo 2,https://medium.com/feed/vue-mastery"
              data-maxcols="3"
              data-layout="slider"
              data-poststyle="inline"
@@ -67,7 +66,7 @@ This is the way your posts are shown in summary.
 | Option | Default | Reqiuired | Details
 |---|--|--|------|
 |id|n/a|Yes|You must set the value of your entry point's id to "retainable-rss-embed".|
-|data-rss|n/a|Yes|You must provide at least one valid url to the RSS endpoint, multiple rss feeds can be combined with a comma separated list|
+|data-rss|n/a|Yes|You must provide at least one valid url to the RSS endpoint, multiple rss feeds can be combined with a comma separated list. You can also choose how many posts fetch for each endpoint just adding the value after the feed url separated by a space: if no value is given all the posts will be fetched.|
 |data-maxcols|2|Optional|must be an interger of 1, 2, 3, 4, 6 or 12 and controls the number of cols display in the index view|
 |data-layout|grid|Optional|Styles the index of available posts, can be set to "grid" or "slider"|
 |data-poststyle|modal|Optional|The style of posts when you click on an excerpt in the index can be set to one of: "modal", "inline" or "external", external opens the post's source with a target of _blank|

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
 
       Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce id purus. In dui magna, posuere eget, vestibulum et, tempor auctor, justo. Aenean imperdiet. Proin pretium, leo ac pellentesque mollis, felis nunc ultrices eros, sed gravida augue augue mollis justo. Curabitur vestibulum aliquam leo.</p>
     <div id="retainable-rss-embed"
-         data-rss="https://www.themembershipguys.com/feed/,https://medium.com/feed/the-antidote, https://medium.com/feed/the-mission"
+         data-rss="https://www.themembershipguys.com/feed/,https://medium.com/feed/the-antidote,https://medium.com/feed/the-mission"
          data-maxcols="4"
          data-layout="slider"
          data-poststyle="inline"

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -3,17 +3,26 @@ export function someAction (context) {
 }
 */
 import axios from "axios";
-export function getPosts({ commit }, rssUrl) {
-  const rssArray = rssUrl.replace(/ /g, "").split(",");
-  rssArray.forEach(rss => {
+export function getPosts({ commit }, rss) {
+
+  const rssArray = rss.split(",");
+  const rssUrlsWithOptionsArray = rssArray.map(rss => {
+    const rssUrlWithOptions = rss.split(" ");
+    return {
+      rssUrl: rssUrlWithOptions[0],
+      rssItemsCount: rssUrlWithOptions[1]
+    }
+  });
+
+  rssUrlsWithOptionsArray.forEach(rssUrlWithOptions => {
     const data = {
-      rss_url: rss
+      rss_url: rssUrlWithOptions.rssUrl
     };
     axios
       .get("https://api.rss2json.com/v1/api.json", { params: data })
       .then(function(response) {
         // handle success
-        const posts = response.data.items;
+        const posts = response.data.items.slice(0,rssUrlWithOptions.rssItemsCount);
         commit("addPosts", posts);
       })
       .catch(function(error) {


### PR DESCRIPTION
Using this parameter it will be possible to limit the number of posts fetched for each endpoint.
To keep backward compatibility, not using any limit will cause all the posts to be fetched